### PR TITLE
feat: update pindel call wrapper

### DIFF
--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -70,7 +70,7 @@ pindel_update_vcf_sequence_dictionary:
   container: "docker://hydragenetics/picard:2.25.0"
 
 pindel_call:
-  bedfile: "reference/twist_DNA_solid.chr1.annotated.bed"
+  include_bed: "reference/twist_DNA_solid.chr1.annotated.bed"
   container: "docker://hydragenetics/pindel:0.2.5b9"
 
 pindel2vcf:

--- a/workflow/rules/pindel.smk
+++ b/workflow/rules/pindel.smk
@@ -40,6 +40,8 @@ rule pindel_call:
         bai="alignment/samtools_merge_bam/{sample}_{type}.bam.bai",
         config="cnv_sv/pindel/{sample}_{type}.cfg",
         ref=config["reference"]["fasta"],
+        include_bed=config.get("pindel_call", {}).get("include_bed", []),
+        exclude_bed=config.get("pindel_call", {}).get("exclude_bed", []),
     output:
         pindel=temp(
             expand(
@@ -58,10 +60,7 @@ rule pindel_call:
             )
         ),
     params:
-        prefix=lambda wildcards: "cnv_sv/pindel/%s_%s" % (wildcards.sample, wildcards.type),
-        extra=" %s %s " % ("-j", config["pindel_call"]["bedfile"])
-        if "bedfile" in config.get("pindel_call", {})
-        else " %s %s" % ("", config.get("pindel_call", {}).get("extra", "")),
+        extra=config.get("pindel_call", {}).get("extra", ""),
     log:
         "cnv_sv/pindel/{sample}_{type}_pindel_call.log",
     benchmark:
@@ -83,7 +82,7 @@ rule pindel_call:
     message:
         "{rule}: detect breakpoints in {wildcards.sample} {wildcards.type}"
     wrapper:
-        "v1.2.0/bio/pindel/call"
+        "v1.17.2/bio/pindel/call"
 
 
 rule pindel2vcf:

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -311,9 +311,16 @@ properties:
     description: parameters for pindel_call
     type: object
     properties:
-      bedfile:
+      include_bed:
         type: string
-        description: bedfile to restrict pindel call
+        description: >
+          bedfile of regions to restrict calling to, incompatible
+          with `exclude_bed`
+      exclude_bed:
+        type: string
+        description: >
+          bedfile of regions to exclude from calling, incompatible
+          with `include_bed`
       benchmark_repeats:
         type: integer
         description: set number of times benchmark should be repeated

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -313,14 +313,10 @@ properties:
     properties:
       include_bed:
         type: string
-        description: >
-          bedfile of regions to restrict calling to, incompatible
-          with `exclude_bed`
+        description: bedfile of regions to restrict calling to, incompatible with `exclude_bed`
       exclude_bed:
         type: string
-        description: >
-          bedfile of regions to exclude from calling, incompatible
-          with `include_bed`
+        description: bedfile of regions to exclude from calling, incompatible with `include_bed`
       benchmark_repeats:
         type: integer
         description: set number of times benchmark should be repeated


### PR DESCRIPTION
Now any bedfiles with regions to include/exclude should be passed as inputs, not in `params.extra`. Also, the output prefix is handled by the wrapper, so no need to define this as a parameter.

This PR fixes #84.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
