### PR TITLE
fix: bump snakemake version to support apptainer

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ hydra-genetics==0.15.0
 jinja2==3.0.1
 pandas>=1.3.1
 singularity==3.0.0
-snakemake==7.8.0
+snakemake>=7.8.3
 tabulate<0.9.0

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -14,7 +14,7 @@ from hydra_genetics.utils.resources import load_resources
 from hydra_genetics.utils.samples import *
 from hydra_genetics.utils.units import *
 
-min_version("7.8.0")
+min_version("7.8.3")
 
 ### Set and validate config file
 


### PR DESCRIPTION
Version numbers don't agree between singularity and apptainer. Snakemake 7.8.3 includes a fix for this.