### PR TITLE
feat: make the tumor cell content optional

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -11,6 +11,9 @@ automap:
   build: "hg38"
   extra: "--DP 10 --minsize 3 --chrX"
 
+cnvkit_export_seg:
+  extra: "--enumerate-chroms"
+
 cnvpytor_readdepth:
   container: "docker://hydragenetics/cnvpytor:1.2.1"
   length_list: ""

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ drmaa==0.7.9
 hydra-genetics==0.15.0
 jinja2==3.0.1
 pandas>=1.3.1
+pulp<2.8.0
 singularity==3.0.0
 snakemake>=7.8.3,<8
 tabulate<0.9.0

--- a/workflow/rules/cnvkit.smk
+++ b/workflow/rules/cnvkit.smk
@@ -43,11 +43,11 @@ rule cnvkit_batch:
 
 rule cnvkit_call:
     input:
-        segments="cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.cns",
+        segment="cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.cns",
         vcf="snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.germline.vcf",
         tc_file=get_tc_file,
     output:
-        segments=temp("cnv_sv/cnvkit_call/{sample}_{type}.{tc_method}.loh.cns"),
+        segment=temp("cnv_sv/cnvkit_call/{sample}_{type}.{tc_method}.loh.cns"),
     params:
         extra=config.get("cnvkit_call", {}).get("extra", ""),
         purity=get_tc,

--- a/workflow/rules/cnvkit.smk
+++ b/workflow/rules/cnvkit.smk
@@ -8,7 +8,7 @@ rule cnvkit_batch:
     input:
         bam="alignment/samtools_merge_bam/{sample}_{type}.bam",
         bai="alignment/samtools_merge_bam/{sample}_{type}.bam.bai",
-        cnv_reference=config.get("cnvkit_batch", {}).get("normal_reference", ""),
+        reference=config.get("cnvkit_batch", {}).get("normal_reference", ""),
     output:
         antitarget_coverage=temp("cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.antitargetcoverage.cnn"),
         bins=temp("cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.bintest.cns"),
@@ -19,7 +19,6 @@ rule cnvkit_batch:
     params:
         extra=config.get("cnvkit_batch", {}).get("extra", ""),
         method=config.get("cnvkit_batch", {}).get("method", "hybrid"),
-        outdir=lambda wildcards, output: os.path.dirname(output[0]),
     log:
         "cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.call.cns.log",
     benchmark:
@@ -38,24 +37,20 @@ rule cnvkit_batch:
         config.get("cnvkit_batch", {}).get("container", config["default_container"])
     message:
         "{rule}: use cnvkit to call cnvs in {wildcards.sample}/{wildcards.sample}_{wildcards.type}"
-    shell:
-        "(cnvkit.py batch {input.bam} "
-        "-r {input.cnv_reference} "
-        "-d {params.outdir} "
-        "-m {params.method} "
-        "{params.extra}) &> {log}"
+    wrapper:
+        "v3.3.6/bio/cnvkit/batch"
 
 
 rule cnvkit_call:
     input:
-        segment="cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.cns",
+        segments="cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.cns",
         vcf="snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.germline.vcf",
         tc_file=get_tc_file,
     output:
-        segment=temp("cnv_sv/cnvkit_call/{sample}_{type}.{tc_method}.loh.cns"),
+        segments=temp("cnv_sv/cnvkit_call/{sample}_{type}.{tc_method}.loh.cns"),
     params:
         extra=config.get("cnvkit_call", {}).get("extra", ""),
-        tc=get_tc,
+        purity=get_tc,
     log:
         "cnv_sv/cnvkit_call/{sample}_{type}.{tc_method}.loh.cns.log",
     benchmark:
@@ -74,12 +69,8 @@ rule cnvkit_call:
         config.get("cnvkit_call", {}).get("container", config["default_container"])
     message:
         "{rule}: call cnvs with loh info into cnv_sv/cnvkit_call/{wildcards.sample}_{wildcards.type}.loh.cns"
-    shell:
-        "(cnvkit.py call {input.segment} "
-        "-v {input.vcf} "
-        "-o {output.segment} "
-        "--purity {params.tc} "
-        "{params.extra}) &> {log}"
+    wrapper:
+        "v3.3.6/bio/cnvkit/call"
 
 
 rule cnvkit_diagram:
@@ -108,11 +99,8 @@ rule cnvkit_diagram:
         config.get("cnvkit_diagram", {}).get("container", config["default_container"])
     message:
         "{rule}: chromosome plot cnv_sv/cnvkit_scatter/{wildcards.sample}_{wildcards.type}.pdf"
-    shell:
-        "(cnvkit.py diagram {input.cnr} "
-        "-s {input.cns} "
-        "-o {output.pdf} "
-        "{params.extra}) &> {log}"
+    wrapper:
+        "v3.3.6/bio/cnvkit/diagram"
 
 
 rule cnvkit_scatter:
@@ -207,9 +195,5 @@ rule cnvkit_export_seg:
         config.get("cnvkit_export_seg", {}).get("container", config["default_container"])
     message:
         "{rule}: export cnvkit segments into seg in {output.seg}"
-    shell:
-        "(cnvkit.py export seg "
-        "{input.segments} "
-        "--enumerate-chroms "
-        "-o {output.seg} "
-        "{params.extra}) &> {log}"
+    wrapper:
+        "v3.3.6/bio/cnvkit/export"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -29,7 +29,7 @@ validate(config, schema="../schemas/resources.schema.yaml")
 
 ### Read and validate samples file
 
-samples = pd.read_table(config["samples"], dtype=str).set_index("sample", drop=False)
+samples = pd.read_table(config["samples"]).set_index("sample", drop=False)
 validate(samples, schema="../schemas/samples.schema.yaml")
 
 ### Read and validate units file
@@ -50,13 +50,20 @@ wildcard_constraints:
 
 
 def get_tc(wildcards):
+    """
+    Get the tumor cell content of a sample. If the tumor content
+    cannot be identified, return an empty string.
+    """
     tc_method = wildcards.tc_method
     if tc_method == "pathology":
+        sample = get_sample(samples, wildcards)
+        if not "tumor_content" in sample:
+            return ""
         return get_sample(samples, wildcards)["tumor_content"]
     else:
         tc_file = f"cnv_sv/{tc_method}_purity_file/{wildcards.sample}_{wildcards.type}.purity.txt"
         if not os.path.exists(tc_file):
-            return -1
+            return ""
         else:
             with open(tc_file, "r") as f:
                 tc = f.read()

--- a/workflow/schemas/samples.schema.yaml
+++ b/workflow/schemas/samples.schema.yaml
@@ -5,8 +5,7 @@ properties:
     type: string
     description: sample id
   tumor_content:
-    type: string
+    type: ["number", "null"]
     description: Tumor content
 required:
   - sample
-  - tumor_content


### PR DESCRIPTION
This PR modifies the cnvkit rules to make use of the cnvkit Snakemake wrapper. This in turn makes it easier to make tumor purity optional for cnvkit call. The tumor content in the samples file can then be specified as an empty string, or as any other [value that `pandas.read_table` will interpret as a missing value](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_table.html).

Closes #154 