### PR TITLE
fix: update container for rule pindel_update_vcf

### DIFF
--- a/.tests/compatibility/config.yaml
+++ b/.tests/compatibility/config.yaml
@@ -102,8 +102,8 @@ manta_run_workflow_tn:
 manta_run_workflow_n:
   container: "docker://hydragenetics/manta:1.6.0"
 
-pindel_update_vcf_sequence_dictionary:
-  container: "docker://hydragenetics/picard:2.25.0"
+pindel_update_vcf:
+  container: "docker://hydragenetics/picard:2.25.4"
 
 pindel_call:
   include_bed: "reference/twist_DNA_solid.chr1.annotated.bed"

--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -95,8 +95,8 @@ manta_run_workflow_tn:
 manta_run_workflow_n:
   container: "docker://hydragenetics/manta:1.6.0"
 
-pindel_update_vcf_sequence_dictionary:
-  container: "docker://hydragenetics/picard:2.25.0"
+pindel_update_vcf:
+  container: "docker://hydragenetics/picard:2.25.4"
 
 pindel_call:
   include_bed: "reference/twist_DNA_solid.chr1.annotated.bed"

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -45,8 +45,8 @@ manta_config_n:
 manta_run_workflow_n:
   container: "docker://hydragenetics/manta:1.6.0"
 
-pindel_update_vcf_sequence_dictionary:
-  container: "docker://hydragenetics/picard:2.25.0"
+pindel_update_vcf:
+  container: "docker://hydragenetics/picard:2.25.4"
 
 smn_caller:
   container: "docker://hydragenetics/smncopynumbercaller:1.1.2"

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -423,8 +423,8 @@ properties:
         type: string
         description: name or path to docker/singularity container
 
-  pindel_update_vcf_sequence_dictionary:
-    description: parameters for pindel_update_vcf_sequence_dictionary
+  pindel_update_vcf:
+    description: parameters for pindel_update_vcf
     type: object
     properties:
       benchmark_repeats:

--- a/workflow/schemas/resources.schema.yaml
+++ b/workflow/schemas/resources.schema.yaml
@@ -467,8 +467,8 @@ properties:
         type: string
         description: max execution time
 
-  pindel_update_vcf_sequence_dictionary:
-    description: resource definitions for pindel_update_vcf_sequence_dictionary
+  pindel_update_vcf:
+    description: resource definitions for pindel_update_vcf
     type: object
     properties:
       mem_mb:


### PR DESCRIPTION
The name of the rule seems to have been updated, but not the corresponding config sections.