### PR TITLE
fix: allow missing TC when generating GATK VCF

### DIFF
--- a/workflow/scripts/gatk_to_vcf.py
+++ b/workflow/scripts/gatk_to_vcf.py
@@ -56,7 +56,7 @@ for line in seg_in:
         baf = columns[9]
         cn = 2*pow(2, float(log_odds_ratio))
         ccn = cn
-        if float(TC) > 0:
+        if TC and float(TC) > 0:
             ccn = round(2 + (cn - 2) * (1/float(TC)), 2)
         cn = round(cn, 2)
         ref = "N"


### PR DESCRIPTION
This PR fixes an issue with the GATK VCF generation when the tumor content is missing.

Ideally a test case for this should be added, but the reason that I did not is that I could not make it work without making a copy of at least parts of the test data, and this felt a bit excessive since it would add almost 10 MB to the repo. The other route I was considering was to add a unit test for the script `gatk_to_vcf.py`, but that would require the script to be rewritten in a way that would allow it to be imported into a test, and this felt out of scope for this PR. See #22.