### PR TITLE
fix: incorrect type for copy number thresholds

### DIFF
--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -30,7 +30,7 @@ cnvkit_scatter:
 
 cnvkit_vcf:
   container: "docker://hydragenetics/cnvkit:0.9.9"
-  hom_del_limit: "0.5"
+  hom_del_limit: 0.5
 
 
 cnvkit_seg:

--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -32,7 +32,6 @@ cnvkit_vcf:
   container: "docker://hydragenetics/cnvkit:0.9.9"
   hom_del_limit: 0.5
 
-
 cnvkit_seg:
   container: "docker://hydragenetics/cnvkit:0.9.9"
 

--- a/.tests/integration/config.yaml
+++ b/.tests/integration/config.yaml
@@ -30,6 +30,8 @@ cnvkit_scatter:
 
 cnvkit_vcf:
   container: "docker://hydragenetics/cnvkit:0.9.9"
+  hom_del_limit: "0.5"
+
 
 cnvkit_seg:
   container: "docker://hydragenetics/cnvkit:0.9.9"

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -122,13 +122,13 @@ properties:
         type: string
         description: name or path to docker/singularity container
       hom_del_limit:
-        type: string
+        type: number
         description: copy number threshold for homozygous deletion
       het_del_limit:
-        type: string
+        type: number
         description: copy number threshold for heterozygous deletion
       dup_limit:
-        type: string
+        type: number
         description: copy number threshold for duplication
 
   cnvkit_export_seg:


### PR DESCRIPTION
This PR addresses an issue when the copy number thresholds are defined in the config. The validation schema requires the values to be strings, but that resulted in an invalid comparison in `scripts/cnvkit_vcf.py`.

Fixes #163