### PR TITLE
fix(sniffles2): add sample-id param to add sample name in VCF

### DIFF
--- a/workflow/rules/sniffles2.smk
+++ b/workflow/rules/sniffles2.smk
@@ -13,6 +13,7 @@ rule sniffles2_call:
         vcf="cnv_sv/sniffles2_call/{sample}_{type}.vcf",
         snf="cnv_sv/sniffles2_call/{sample}_{type}.snf",
     params:
+        sample_id=lambda wildcards, output: "{}_{}".format(wildcards.sample, wildcards.type),
         tandem_repeats=get_tr_bed,
         extra=config.get("sniffles2_call", {}).get("extra", ""),
     log:
@@ -37,6 +38,7 @@ rule sniffles2_call:
         "sniffles -i {input.bam} "
         "--reference {input.ref} "
         "-t {threads} "
+        "--sample-id {params.sample_id} "
         "{params.tandem_repeats} "
         "{params.extra} "
         "--vcf {output.vcf} "


### PR DESCRIPTION
By default sniffles2 will add SAMPLE in the header of the sample_id column of a single sample vcf

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
