### PR TITLE
fix: correct alignment_path and index_path in get_input_bam()

### DIFF
--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -109,8 +109,8 @@ def get_input_bam(wildcards, default_path="alignment/samtools_merge_bam"):
     else:
         # if neither input_bam nor aligner entries are in the config
         # use default bam path to compile output
-        alignment_path = f"{default_path}/{wildcards.sample}_{wildcards.sample}.bam"
-        index_path = f"{default_path}/{wildcards.sample}_{wildcards.sample}.bam.bai"
+        alignment_path = f"{default_path}/{wildcards.sample}_{wildcards.type}.bam"
+        index_path = f"{default_path}/{wildcards.sample}_{wildcards.type}.bam.bai"
     return alignment_path, index_path
 
 


### PR DESCRIPTION
in case when neither unit_bam nor aligner entries are present in config, both the alignment and index paths should include 'wildcards.type' not 'wildcards.sample' twice

### This PR:

Fixed: alignment and index paths after 'else' statement 

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
