### PR TITLE
fix: limit number of threads used by Jumble to that specified in config

### DIFF
--- a/workflow/rules/jumble.smk
+++ b/workflow/rules/jumble.smk
@@ -38,7 +38,9 @@ rule jumble_run:
     message:
         "{rule}: Call CNVs with jumble on {input.bam}"
     shell:
-        "(Rscript /Jumble/jumble-run.R "
+        "(OMP_NUM_THREADS={threads} "
+        "MKL_NUM_THREADS={threads} "
+        "Rscript /Jumble/jumble-run.R "
         "-r {params.reference} "
         "-b {input.bam} "
         "-v {input.vcf} "


### PR DESCRIPTION
### This PR:


Fixed: Make sure jumble-run is not using more cores than specified in config. Fixed by setting environment variables OMP_NUM_THREADS and MKL_NUM_THREADS to config threads when calling jumble-run.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
