### PR TITLE
fix: pindel_update_vcf fails if not --notemp used

### DIFF
--- a/workflow/rules/pindel.smk
+++ b/workflow/rules/pindel.smk
@@ -132,9 +132,8 @@ rule pindel_update_vcf:
         vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_contig.vcf",
     output:
         vcf=temp("cnv_sv/pindel_vcf/{sample}_{type}.no_tc.vcf"),
-        samplename=temp("cnv_sv/pindel_vcf/{sample}_{type}.samplename.txt"),
     params:
-        extra=config.get("pindel_update_vcf", {}).get("extra", ""),
+        samplename_tmp="cnv_sv/pindel_vcf/{sample}_{type}.samplename.txt",
     log:
         "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.vcf.log",
     benchmark:
@@ -154,8 +153,8 @@ rule pindel_update_vcf:
     message:
         "{rule}: update cnv_sv/pindel/{wildcards.sample}_{wildcards.type}.no_contig.vcf to include contigs and correct samplename"
     shell:
-        "(echo -e '{wildcards.sample}_{wildcards.type}\n' > {output.samplename} && "
+        "(echo -e '{wildcards.sample}_{wildcards.type}\n' > {params.samplename_tmp} && "
         "picard UpdateVcfSequenceDictionary "
         "-INPUT {input.vcf} -QUIET true "
         "-SD {input.fasta} "
-        "-OUTPUT /dev/stdout | bcftools reheader -s {output.samplename} -o {output.vcf} - )&> {log}"
+        "-OUTPUT /dev/stdout | bcftools reheader -s {output.samplename} -o {output.vcf} - && rm {params.samplename_tmp} )&> {log}"

--- a/workflow/rules/pindel.smk
+++ b/workflow/rules/pindel.smk
@@ -157,4 +157,4 @@ rule pindel_update_vcf:
         "picard UpdateVcfSequenceDictionary "
         "-INPUT {input.vcf} -QUIET true "
         "-SD {input.fasta} "
-        "-OUTPUT /dev/stdout | bcftools reheader -s {output.samplename} -o {output.vcf} - && rm {params.samplename_tmp} )&> {log}"
+        "-OUTPUT /dev/stdout | bcftools reheader -s {params.samplename_tmp} -o {output.vcf} - && rm {params.samplename_tmp} )&> {log}"


### PR DESCRIPTION
Snakemake removes the `{output.samplename}` as soon as created even if the rule has not finished, moved `samplename` to params and added a rm command instead

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary file handling in variant processing to ensure proper cleanup and prevent file conflicts during workflow execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hydra-genetics/cnv_sv/pull/288?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->