### PR TITLE
fix: pindel_update_vcf fails if not --notemp used (#288)

### DIFF
--- a/workflow/rules/pindel.smk
+++ b/workflow/rules/pindel.smk
@@ -132,9 +132,8 @@ rule pindel_update_vcf:
         vcf="cnv_sv/pindel_vcf/{sample}_{type}.no_contig.vcf",
     output:
         vcf=temp("cnv_sv/pindel_vcf/{sample}_{type}.no_tc.vcf"),
-        samplename=temp("cnv_sv/pindel_vcf/{sample}_{type}.samplename.txt"),
     params:
-        extra=config.get("pindel_update_vcf", {}).get("extra", ""),
+        samplename_tmp="cnv_sv/pindel_vcf/{sample}_{type}.samplename.txt",
     log:
         "cnv_sv/pindel_vcf/{sample}_{type}.no_tc.vcf.log",
     benchmark:
@@ -154,8 +153,8 @@ rule pindel_update_vcf:
     message:
         "{rule}: update cnv_sv/pindel/{wildcards.sample}_{wildcards.type}.no_contig.vcf to include contigs and correct samplename"
     shell:
-        "(echo -e '{wildcards.sample}_{wildcards.type}\n' > {output.samplename} && "
+        "(echo -e '{wildcards.sample}_{wildcards.type}\n' > {params.samplename_tmp} && "
         "picard UpdateVcfSequenceDictionary "
         "-INPUT {input.vcf} -QUIET true "
         "-SD {input.fasta} "
-        "-OUTPUT /dev/stdout | bcftools reheader -s {output.samplename} -o {output.vcf} - )&> {log}"
+        "-OUTPUT /dev/stdout | bcftools reheader -s {params.samplename_tmp} -o {output.vcf} - && rm {params.samplename_tmp} )&> {log}"


### PR DESCRIPTION
* fix: pindel_update_vcf fails if not --notemp used

Snakemake removes the `{output.samplename}` as soon as created even if the rule has not finished, moved `samplename` to params and added a rm command instead

* fix: changed missed output.samplename to params.samplename_tmp

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
