### PR TITLE
feat: remove the depedency on peddy for exomedepth and expansiohunter

### DIFF
--- a/.tests/integration/samples.tsv
+++ b/.tests/integration/samples.tsv
@@ -1,5 +1,5 @@
 sample	tumor_content	sex	trioid	trio_member
-HD832.HES45	1	NA	NA	NA
+HD832.HES45	1	male	NA	NA
 sample2	0	male	Trio1	proband
 sample3	0	male	Trio1	mother
 sample4	0	female	Trio1	father

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -29,6 +29,15 @@ Returns a `(bam, bai)` tuple for haplotagged BAM files. Respects `haplotag_path`
 ### `get_severus_tn_input(wildcards)` *(defined in `workflow/rules/common.smk`)*
 Returns a dict `{"bam_t": ..., "bam_n": ...}` for use with Snakemake's `unpack()`. Calls `get_input_haplotagged_bam` twice with fixed `type="T"` and `type="N"` for the same sample, regardless of `wildcards.type`. Inherits `haplotag_path` and `haplotag_suffix` config behaviour. Used by: `severus_tn`.
 
+### `get_sample_sex(sample)` *(defined in `workflow/rules/common.smk`)*
+Returns the sex of a sample from the `samples` dataframe. If the `sex` column is missing from the samplesheet or if the value is `NA`, it defaults to "female". Used by: `expansionhunter`, `get_exomedepth_ref`, `get_karyotype`, `get_expected_cn`.
+
+### `get_exomedepth_ref(wildcards)` *(defined in `workflow/rules/common.smk`)*
+Returns the appropriate reference count file for ExomeDepth based on sample sex (via `get_sample_sex`). Used by: `exomedepth_call`.
+
+### `get_karyotype(wildcards)` *(defined in `workflow/rules/common.smk`)*
+Translates sample sex (via `get_sample_sex`) to a karyotype string (e.g., "XY" for male, "XX" for female). Used by: `trgt_genotype`.
+
 ## Module output files
 The output consists of result files that describe different kinds of larger genomic aberrations, such as copy number aberrations (CNVs), structural variants (SVs), and repeat expansions. The output files below are subdivided into short-read and long-read categories.
 

--- a/docs/softwares.md
+++ b/docs/softwares.md
@@ -282,29 +282,6 @@ ExomeDepth is a R package designed to detect inherited copy number variants (CNV
 
 ---
 
-### [ExomeDepth_sex](https://github.com/vplagnol/ExomeDepth)
-ExomeDepth is a R package designed to detect inherited copy number variants (CNVs) using high throughput DNA sequence data (WES or panels). This rule only copies the peddy sex file to a copy used by ExomeDepth.
-
-#### :snake: Rule
-
-#SNAKEMAKE_RULE_SOURCE__exomedepth__exomedepth_sex#
-
-##### :left_right_arrow: input / output files
-
-#SNAKEMAKE_RULE_TABLE__exomedepth__exomedepth_sex#
-
-#### :wrench: Configuration
-
-##### Software settings (`config.yaml`)
-
-#CONFIGSCHEMA__exomedepth_sex#
-
-##### Resources settings (`resources.yaml`)
-
-#RESOURCESSCHEMA__exomedepth_sex#
-
----
-
 ## [ExpansionHunter](https://github.com/Illumina/ExpansionHunter)
 Expansion Hunter aims to estimate sizes of selected repeats by performing a targeted search through a BAM/CRAM file for reads that span, flank, and are fully contained in each repeat.
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -53,7 +53,7 @@ wildcard_constraints:
 
 def get_sample_sex(sample):
     """
-    Get the sex of a sample from the samples dataframe. 
+    Get the sex of a sample from the samples dataframe.
     If the sex column is missing or the value is NA, return "female" as default.
     """
     if "sex" not in samples.columns:
@@ -92,7 +92,7 @@ def get_expected_cn(wildcards):
     if "sex" not in samples.columns:
         return ""
     sex = get_sample_sex(wildcards.sample)
-    
+
     if sex == "male":
         expected_cn = config.get("sawfish_discover", {}).get("expected_cn", {}).get("male", "")
         sawfish_param = f"--expected-cn {expected_cn}"

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -187,17 +187,8 @@ def get_purecn_extra(wildcards: snakemake.io.Wildcards, input: snakemake.io.Inpu
     return extra
 
 
-def get_peddy_sex(wildcards, peddy_sex_check):
-    sample = "{}_{}".format(wildcards.sample, wildcards.type)
-    sex_df = pd.read_table(peddy_sex_check, sep=",").set_index("sample_id", drop=False)
-
-    sample_sex = sex_df.at[sample, "predicted_sex"]
-
-    return sample_sex
-
-
 def get_exomedepth_ref(wildcards):
-    sex = get_peddy_sex(wildcards, checkpoints.exomedepth_sex.get().output[0])
+    sex = samples.loc[wildcards.sample].sex
 
     if sex == "male":
         ref = config.get("exomedepth_call", {}).get("male_reference", "")

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -51,6 +51,21 @@ wildcard_constraints:
     file="^cnv_sv/.+",
 
 
+def get_sample_sex(sample):
+    """
+    Get the sex of a sample from the samples dataframe. 
+    If the sex column is missing or the value is NA, return "female" as default.
+    """
+    if "sex" not in samples.columns:
+        return "female"
+
+    sex = samples.at[sample, "sex"]
+    if pd.isna(sex):
+        return "female"
+
+    return sex
+
+
 def get_karyotype(wildcards):
     """
     Translate sex to karyotype for trgt. If sex is unknown
@@ -58,7 +73,8 @@ def get_karyotype(wildcards):
     as default
     """
 
-    sex = samples.loc[wildcards.sample].sex
+    sex = get_sample_sex(wildcards.sample)
+
     if sex == "male":
         karyotype = "XY"
     else:
@@ -73,10 +89,10 @@ def get_expected_cn(wildcards):
     These bed are typically used to specify ploidy in the non-PAR regions of the sex chromosomes.
     """
 
-    try:
-        sex = samples.loc[wildcards.sample].sex
-    except AttributeError:
+    if "sex" not in samples.columns:
         return ""
+    sex = get_sample_sex(wildcards.sample)
+    
     if sex == "male":
         expected_cn = config.get("sawfish_discover", {}).get("expected_cn", {}).get("male", "")
         sawfish_param = f"--expected-cn {expected_cn}"
@@ -188,7 +204,7 @@ def get_purecn_extra(wildcards: snakemake.io.Wildcards, input: snakemake.io.Inpu
 
 
 def get_exomedepth_ref(wildcards):
-    sex = samples.loc[wildcards.sample].sex
+    sex = get_sample_sex(wildcards.sample)
 
     if sex == "male":
         ref = config.get("exomedepth_call", {}).get("male_reference", "")

--- a/workflow/rules/exomedepth.smk
+++ b/workflow/rules/exomedepth.smk
@@ -4,40 +4,10 @@ __email__ = "arielle.munters@scilifelab.uu.se, padraic.corcoran@scilifelab.uu.se
 __license__ = "GPL-3"
 
 
-checkpoint exomedepth_sex:
-    input:
-        peddy="qc/peddy/peddy.sex_check.csv",
-    output:
-        peddy="qc/peddy/peddy.sex_check-checkpoint.csv",
-    params:
-        extra=config.get("exomedepth_sex", {}).get("extra", ""),
-    log:
-        "qc/peddy/peddy.sex_check-checkpoint.csv.log",
-    benchmark:
-        repeat(
-            "qc/peddy/peddy.sex_check-checkpoint.csv.benchmark.tsv",
-            config.get("exomedepth_sex", {}).get("benchmark_repeats", 1),
-        )
-    threads: config.get("exomedepth_sex", {}).get("threads", config["default_resources"]["threads"])
-    resources:
-        mem_mb=config.get("exomedepth_sex", {}).get("mem_mb", config["default_resources"]["mem_mb"]),
-        mem_per_cpu=config.get("exomedepth_sex", {}).get("mem_per_cpu", config["default_resources"]["mem_per_cpu"]),
-        partition=config.get("exomedepth_sex", {}).get("partition", config["default_resources"]["partition"]),
-        threads=config.get("exomedepth_sex", {}).get("threads", config["default_resources"]["threads"]),
-        time=config.get("exomedepth_sex", {}).get("time", config["default_resources"]["time"]),
-    container:
-        config.get("exomedepth_sex", {}).get("container", config["default_container"])
-    message:
-        "{rule}: checkpoint with {input.peddy}"
-    shell:
-        "cp {input.peddy} {output.peddy}"
-
-
 rule exomedepth_call:
     input:
         bam="alignment/samtools_merge_bam/{sample}_{type}.bam",
         bedfile=config.get("exomedepth_call", {}).get("bedfile", ""),
-        sex="qc/peddy/peddy.sex_check-checkpoint.csv",
         ref_count=get_exomedepth_ref,
     output:
         exon=temp("cnv_sv/exomedepth_call/{sample}_{type}.RData"),

--- a/workflow/rules/expansionhunter.smk
+++ b/workflow/rules/expansionhunter.smk
@@ -10,7 +10,6 @@ rule expansionhunter:
         bai="alignment/samtools_merge_bam/{sample}_{type}.bam.bai",
         cat=config.get("expansionhunter", {}).get("variant_catalog", ""),
         ref=config.get("reference", {}).get("fasta", ""),
-        sex="qc/peddy/peddy.sex_check.csv",
     output:
         bam=temp("cnv_sv/expansionhunter/{sample}_{type}_realigned.bam"),
         json=temp("cnv_sv/expansionhunter/{sample}_{type}.json"),
@@ -18,7 +17,7 @@ rule expansionhunter:
     params:
         extra=config.get("expansionhunter", {}).get("extra", ""),
         prefix=lambda wildcards, output: "{}/{}_{}".format(os.path.split(output.vcf)[0], wildcards.sample, wildcards.type),
-        sex=lambda wildards, input: get_peddy_sex(wildards, input.sex),
+        sex=lambda wildcards, input: samples.loc[wildcards.sample].sex,
     log:
         "cnv_sv/expansionhunter/{sample}_{type}.output.log",
     benchmark:

--- a/workflow/rules/expansionhunter.smk
+++ b/workflow/rules/expansionhunter.smk
@@ -17,7 +17,7 @@ rule expansionhunter:
     params:
         extra=config.get("expansionhunter", {}).get("extra", ""),
         prefix=lambda wildcards, output: "{}/{}_{}".format(os.path.split(output.vcf)[0], wildcards.sample, wildcards.type),
-        sex=lambda wildcards, input: samples.loc[wildcards.sample].sex,
+        sex=lambda wildcards, input: get_sample_sex(wildcards.sample),
     log:
         "cnv_sv/expansionhunter/{sample}_{type}.output.log",
     benchmark:

--- a/workflow/schemas/rules.schema.yaml
+++ b/workflow/schemas/rules.schema.yaml
@@ -256,25 +256,6 @@ properties:
             type: string
             description: manhattan plot of read depth in 'png' file format
 
-  exomedepth_sex:
-    type: object
-    description: input and output parameters for exomedepth_sex
-    properties:
-      input:
-        type: object
-        description: list of inputs
-        properties:
-          peddy:
-            type: string
-            description: a 'peddy' sex file
-      output:
-        type: object
-        description: list of outputs
-        properties:
-          peddy:
-            type: string
-            description: a 'peddy' sex file used by exomedepth
-    
   exomedepth_call:
     type: object
     description: input and output parameters for exomedepth_call
@@ -289,9 +270,6 @@ properties:
           bedfile:
             type: string
             description: a 'bed' file with regions to be analyzed
-          sex:
-            type: string
-            description: a 'peddy' sex file
           ref_count:
             type: string
             description: file with panel of normal reference panel, male or female
@@ -326,9 +304,6 @@ properties:
           ref:
             type: string
             description: fasta genome reference file
-          sex:
-            type: string
-            description: a 'peddy' sex file
       output:
         type: object
         description: list of outputs


### PR DESCRIPTION
### This PR:


Removed: removed the need to infer sample sex with peddy for exomedepth and expansionhunter. Now the sex of the sample is obtained from the samples.tsv file. Other methods for inferring sample sex should be handled at the pipeline level and not in the hydra-module.


### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactoring**
  * Removed the separate sex-prediction step; analyses now derive sample sex directly from sample metadata, simplifying sex handling for exome and repeat analyses.

* **Documentation**
  * Updated docs to reflect removal of the exome-sex analysis module and to document the helper utilities that determine sample sex and karyotype.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hydra-genetics/cnv_sv/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->