### PR TITLE
fix(melt): handle empty vcf files produced by melt

### DIFF
--- a/workflow/rules/melt.smk
+++ b/workflow/rules/melt.smk
@@ -54,7 +54,14 @@ rule melt:
         cp {output.tmpdir}/ALU.final_comp.vcf {output.alu} && \
         cp {output.tmpdir}/HERVK.final_comp.vcf {output.hervk} && \
         cp {output.tmpdir}/LINE1.final_comp.vcf {output.line1} && \
-        cp {output.tmpdir}/SVA.final_comp.vcf {output.sva}) \
+        cp {output.tmpdir}/SVA.final_comp.vcf {output.sva} && \
+        s="{wildcards.sample}_{wildcards.type}" && \
+        for vcf in {output.alu} {output.hervk} {output.line1} {output.sva}; do \
+            if [ ! -s "$vcf" ]; then \
+                printf '##fileformat=VCFv4.2\n' > "$vcf" && \
+                printf '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t%s\n' "$s" >> "$vcf"; \
+            fi; \
+        done) \
         &> {log}
         """
 


### PR DESCRIPTION
### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved MELT output handling so missing or empty element VCFs are now replaced with valid placeholder VCF headers.
  * Ensured the final SVA VCF is preserved first, and all expected element outputs are consistently available for downstream steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->