### PR TITLE
fix: add sniffles2 container

### DIFF
--- a/.tests/integration/config_pacbio.yaml
+++ b/.tests/integration/config_pacbio.yaml
@@ -56,6 +56,9 @@ sniffles2_call:
   container: "docker://hydragenetics/sniffles2:2.4"
   tandem_repeats: "reference/human_GRCh38_no_alt_analysis_set.trf.bed"
 
+sniffles2_joint_call:
+  container: "docker://hydragenetics/sniffles2:2.4"
+
 severus_t_only:
   container: "docker://hydragenetics/severus:1.5"
   vntr: "reference/human_GRCh38_no_alt_analysis_set.trf.bed"


### PR DESCRIPTION
for rule sniffles2_joint_call in integration test config (config_pacbio.yaml)

### This PR:

Fixed: added container path fixes integration test crash

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Sniffles2 joint-calling resource in the PacBio integration configuration.
  * Updated the setup to use a specific Sniffles2 container version for this workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->